### PR TITLE
feat: image resize

### DIFF
--- a/client/src/app/_components/ImageUpload.tsx
+++ b/client/src/app/_components/ImageUpload.tsx
@@ -100,7 +100,7 @@ export default function ImageUpload() {
               className="rounded-lg overflow-hidden shadow-md border border-gray-200"
             >
               <Image
-                src={url}
+                src={`${url}?width=960`}
                 alt="uploaded image"
                 width={960}
                 height={960}

--- a/infrastructure/index.ts
+++ b/infrastructure/index.ts
@@ -5,7 +5,6 @@ import {
   R2_BUCKET_NAME,
   R2_BUCKET_REGION,
 } from "@workers-image-resize-delivery/common/constants";
-// import { local } from "@pulumi/command";
 
 config();
 
@@ -24,15 +23,16 @@ new cloudflare.R2BucketCors("r2_bucket_cors", {
   rules: [
     {
       allowed: {
-        origins: [env.APP_URL],
-        methods: ["PUT"],
+        origins: [env.NEXT_PUBLIC_CDN_URL, env.APP_URL],
+        methods: ["GET", "PUT"],
         headers: ["*"],
       },
     },
   ],
 });
 
-// workersをデプロイする場合は下記
-// new local.Command("run-deploy", {
-//   create: "cd ../cdn && pnpm run deploy"
-// });
+new cloudflare.R2ManagedDomain("r2_bucket_domain", {
+  accountId,
+  bucketName: R2_BUCKET_NAME,
+  enabled: true,
+});

--- a/infrastructure/package.json
+++ b/infrastructure/package.json
@@ -14,7 +14,6 @@
   },
   "dependencies": {
     "@pulumi/cloudflare": "^6.2.0",
-    "@pulumi/command": "^1.1.0",
     "@pulumi/pulumi": "^3.113.0",
     "@workers-image-resize-delivery/common": "workspace:*",
     "dotenv": "^16.5.0"

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "scripts": {
     "build": "turbo run build",
     "dev": "turbo run dev",
-    "up": "turbo run up",
+    "up": "turbo run up && cd cdn && pnpm run deploy",
     "down": "turbo run down",
     "lint": "turbo run lint",
     "format": "prettier --write \"**/*.{ts,tsx,md}\"",

--- a/packages/common/env.ts
+++ b/packages/common/env.ts
@@ -3,10 +3,11 @@ import * as v from "valibot";
 const EnvSchema = v.object({
   NEXT_PUBLIC_CDN_URL: v.pipe(v.string(), v.url()),
   APP_URL: v.pipe(v.string(), v.url()),
+  BUCKET_URL: v.pipe(v.string(), v.url()),
   // CLOUDFLARE_APEX_DOMAIN: v.string(),
   CLOUDFLARE_ACCOUNT_ID: v.string(),
   // ZONE_ID: v.string(),
-  CLOUDFLARE_API_TOKEN: v.string(),
+  // CLOUDFLARE_API_TOKEN: v.string(),
   CLOUDFLARE_R2_ENDPOINT: v.pipe(v.string(), v.url()),
   CLOUDFLARE_R2_ACCESS_KEY_ID: v.string(),
   CLOUDFLARE_R2_SECRET_ACCESS_KEY: v.string(),

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -109,9 +109,6 @@ importers:
       '@pulumi/cloudflare':
         specifier: ^6.2.0
         version: 6.2.0(ts-node@10.9.2(@types/node@18.19.110)(typescript@5.8.2))(typescript@5.8.2)
-      '@pulumi/command':
-        specifier: ^1.1.0
-        version: 1.1.0(ts-node@10.9.2(@types/node@18.19.110)(typescript@5.8.2))(typescript@5.8.2)
       '@pulumi/pulumi':
         specifier: ^3.113.0
         version: 3.173.0(ts-node@10.9.2(@types/node@18.19.110)(typescript@5.8.2))(typescript@5.8.2)
@@ -1160,9 +1157,6 @@ packages:
 
   '@pulumi/cloudflare@6.2.0':
     resolution: {integrity: sha512-PXTYyf1oUoaiGsHUzFtKwlNySkA6IzS37TpYo3gvpem6R+x4Ot3t3sGQCuPi24a5TweeAmPPSY33+EGjqlAIhw==}
-
-  '@pulumi/command@1.1.0':
-    resolution: {integrity: sha512-ovVec+gXeqpcm76xwYYZvfJym8bG9NRvlBGQWbn0+c0fKQziZIjiv5V+AxTKfb+dLWKe7Otyt206L1IWq41hyw==}
 
   '@pulumi/pulumi@3.173.0':
     resolution: {integrity: sha512-/qvSyYaNBV8RpB+B24H2CqF7DA+OHzUqMa/NUJWmCE41UNHPlscFgNMfR0EV7IKqH0woKtzA3DOloBZfPjINVg==}
@@ -5092,15 +5086,6 @@ snapshots:
   '@protobufjs/utf8@1.1.0': {}
 
   '@pulumi/cloudflare@6.2.0(ts-node@10.9.2(@types/node@18.19.110)(typescript@5.8.2))(typescript@5.8.2)':
-    dependencies:
-      '@pulumi/pulumi': 3.173.0(ts-node@10.9.2(@types/node@18.19.110)(typescript@5.8.2))(typescript@5.8.2)
-    transitivePeerDependencies:
-      - bluebird
-      - supports-color
-      - ts-node
-      - typescript
-
-  '@pulumi/command@1.1.0(ts-node@10.9.2(@types/node@18.19.110)(typescript@5.8.2))(typescript@5.8.2)':
     dependencies:
       '@pulumi/pulumi': 3.173.0(ts-node@10.9.2(@types/node@18.19.110)(typescript@5.8.2))(typescript@5.8.2)
     transitivePeerDependencies:


### PR DESCRIPTION
close: https://github.com/sendo-kakeru/workers-image-resize-delivery/issues/9
close: https://github.com/sendo-kakeru/workers-image-resize-delivery/issues/3

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Images can now be dynamically resized on delivery by specifying width and height (up to 3000px) in the image URL.
	- Added managed domain support for the image storage bucket, improving CDN integration.

- **Improvements**
	- Uploaded images are now displayed at a width of 960px for optimized loading.
	- Expanded CORS support to allow more origins and HTTP methods for image storage access.
	- Updated environment validation to require a bucket URL for image delivery.

- **Chores**
	- Updated deployment scripts and removed unused dependencies for a cleaner setup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->